### PR TITLE
Async JWT getter setter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,12 @@
       "integrity": "sha1-0ifxi8uPPxh+FpZfJESFmgRol1g=",
       "dev": true
     },
+    "@types/isomorphic-fetch": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz",
+      "integrity": "sha1-PDSD5gbAQTeEOOlRRk8A5OYHBtY=",
+      "dev": true
+    },
     "@types/jwt-decode": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/jwt-decode/-/jwt-decode-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@mymicds/configs": "^1.0.0",
     "@types/form-data": "^2.2.1",
+    "@types/isomorphic-fetch": "0.0.34",
     "@types/jwt-decode": "^2.2.1",
     "@types/node": "^8.5.2",
     "@types/qs": "^6.5.1",

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,3 +1,4 @@
+import { MyMICDS } from './sdk';
 import { APIResponse } from './api-response';
 import { MyMICDSError } from './error';
 import { MyMICDSOptions } from './options';
@@ -12,7 +13,7 @@ export class HTTP {
 	private errorsSubject = new Subject<MyMICDSError>();
 	errors = this.errorsSubject.asObservable();
 
-	constructor(private options: MyMICDSOptions) { }
+	constructor(private sdk: MyMICDS) { }
 
 	get<T>(endpoint: string, data?: StringDict) {
 		return this.http<T>(HTTPMethod.GET, endpoint, data);
@@ -52,12 +53,12 @@ export class HTTP {
 		const headers = new Headers();
 		headers.append('Content-Type', 'application/json');
 		headers.append('Accept', 'application/json');
-		const jwt = this.options.jwtGetter();
+		const jwt = this.sdk.options.jwtGetter();
 		if (jwt) {
 			headers.append('Authorization', `Bearer ${jwt}`);
 		}
 
-		return this.fetchApi<T>(`${this.options.baseURL}${endpoint}${query}`, {
+		return this.fetchApi<T>(`${this.sdk.options.baseURL}${endpoint}${query}`, {
 			method,
 			body,
 			headers
@@ -78,7 +79,7 @@ export class HTTP {
 
 		const headers = new Headers();
 		headers.append('Accept', 'application/json');
-		const jwt = this.options.jwtGetter();
+		const jwt = this.sdk.getJwt();
 		if (jwt) {
 			headers.append('Authorization', `Bearer ${jwt}`);
 		}
@@ -88,7 +89,7 @@ export class HTTP {
 			form.append(k, data[k]);
 		});
 
-		return this.fetchApi<T>(`${this.options.baseURL}${endpoint}`, {
+		return this.fetchApi<T>(`${this.sdk.options.baseURL}${endpoint}`, {
 			method,
 			body: form,
 			headers

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -31,7 +31,7 @@ export class AuthAPI {
 			switchMap(res => {
 				const parsed = AuthAPI.parseJWT(res.jwt);
 				// If login successful, store JWT
-				let loginAction: Observable<void> = of();
+				let loginAction: Observable<any> = of({});
 				if (parsed) {
 					loginAction = this.storeJWTAndEmitStatus(res.jwt, parsed.payload, param.remember);
 				}

--- a/src/libs/auth.ts
+++ b/src/libs/auth.ts
@@ -6,7 +6,7 @@ import { HTTP } from '../http';
 import { MyMICDS } from '../sdk';
 
 import { BehaviorSubject, Observable, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 
 import * as decode from 'jwt-decode';
 
@@ -21,40 +21,46 @@ export class AuthAPI {
 	}
 
 	constructor(private http: HTTP, private mymicds: MyMICDS) {
-		const parsed = this.retrieveAndParseJWT();
-		this.emitJWTStatus(parsed ? parsed.payload : null);
+		this.retrieveAndParseJWT().subscribe(parsed => {
+			this.emitJWTStatus(parsed ? parsed.payload : null);
+		});
 	}
 
 	login(param: LoginParameters) {
 		return this.http.post<LoginResponse>('/auth/login', param).pipe(
-			tap(res => {
+			switchMap(res => {
 				const parsed = AuthAPI.parseJWT(res.jwt);
+				// If login successful, store JWT
+				let loginAction: Observable<void> = of();
 				if (parsed) {
-					this.storeJWTAndEmitStatus(res.jwt, parsed.payload, param.remember);
+					loginAction = this.storeJWTAndEmitStatus(res.jwt, parsed.payload, param.remember);
 				}
+				return loginAction.pipe(map(() => res));
 			})
 		);
 	}
 
 	logout() {
-		let logoutAction: Observable<{}>;
-		if (typeof this.mymicds.options.jwtGetter() === 'string') {
-			logoutAction = this.http.post('/auth/logout');
-		} else {
-			// Already logged out. No need to logout with backend, just make sure there is not JWT.
-			logoutAction = of({});
-		}
-		return logoutAction.pipe(
-			tap(() => {
-				this.clearJwt();
-			})
+		return this.mymicds.getJwt().pipe(
+			switchMap(jwt => {
+				if (jwt) {
+					return this.http.post('/auth/logout');
+				} else {
+					// Already logged out. No need to logout with backend, just make sure there is not JWT.
+					return of({});
+				}
+			}),
+			switchMap(() => this.clearJwt())
 		);
 	}
 
 	clearJwt() {
-		this.mymicds.options.jwtClear();
-		this.snapshot = null;
-		this.emitJWTStatus(null);
+		return this.mymicds.clearJwt().pipe(
+			tap(() => {
+				this.snapshot = null;
+				this.emitJWTStatus(null);
+			})
+		);
 	}
 
 	register(param: RegisterParameters) {
@@ -82,17 +88,19 @@ export class AuthAPI {
 	}
 
 	private retrieveAndParseJWT() {
-		const rawJWT = this.mymicds.options.jwtGetter();
-		if (!rawJWT) {
-			return null;
-		}
-		const parsed = AuthAPI.parseJWT(rawJWT);
-		// Check if JWT is invalid
-		if (!parsed) {
-			this.mymicds.options.jwtClear();
-			return null;
-		}
-		return parsed;
+		return this.mymicds.getJwt().pipe(
+			switchMap(rawJWT => {
+				if (!rawJWT) {
+					return of(null);
+				}
+				const parsed = AuthAPI.parseJWT(rawJWT);
+				// Check if JWT is invalid
+				if (!parsed) {
+					return this.mymicds.clearJwt().pipe(map(() => null));
+				}
+				return of(parsed);
+			})
+		);
 	}
 
 	private static parseJWT(rawJWT: string): ParsedJWT | null {
@@ -112,8 +120,9 @@ export class AuthAPI {
 	}
 
 	private storeJWTAndEmitStatus(jwt: string, payload: JWT, remember?: boolean) {
-		this.mymicds.options.jwtSetter(jwt, remember);
-		this.emitJWTStatus(payload);
+		return this.mymicds.setJwt(jwt, remember).pipe(
+			tap(() => this.emitJWTStatus(payload))
+		);
 	}
 
 	private emitJWTStatus(payload: JWT | null) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,9 +3,9 @@ declare const sessionStorage: Storage;
 
 export interface MyMICDSOptions {
 	baseURL: string;
-	jwtGetter(): string | null;
-	jwtSetter(jwt: string, remember?: boolean): void;
-	jwtClear(): void;
+	jwtGetter(): string | null | Promise<string | null>;
+	jwtSetter(jwt: string, remember?: boolean): void | Promise<void>;
+	jwtClear(): void | Promise<void>;
 	updateBackground: boolean;
 	updateUserInfo: boolean;
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -96,4 +96,20 @@ export class MyMICDS {
 		this.weather = new WeatherAPI(http);
 	}
 
+	async getJwt() {
+		try {
+			return await Promise.resolve(this.options.jwtGetter());
+		} catch {
+			return null;
+		}
+	}
+
+	async setJwt(jwt: string, remember: boolean) {
+		return await Promise.resolve(this.options.jwtSetter(jwt, remember));
+	}
+
+	async clearJwt() {
+		return await Promise.resolve(this.options.jwtClear());
+	}
+
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,4 +1,4 @@
-import { Subject } from 'rxjs';
+import { from, Subject } from 'rxjs';
 import { Action } from './api-response';
 import { MyMICDSError } from './error';
 import { HTTP } from './http';
@@ -62,7 +62,7 @@ export class MyMICDS {
 	constructor(options?: Partial<MyMICDSOptions>) {
 		this.options = Object.assign({}, defaultOptions, options);
 
-		const http = new HTTP(this.options);
+		const http = new HTTP(this);
 		http.errors.subscribe(error => {
 			// Clear JWT if invalid
 			if (error.action && [Action.LOGIN_EXPIRED, Action.NOT_LOGGED_IN].includes(error.action)) {
@@ -96,20 +96,16 @@ export class MyMICDS {
 		this.weather = new WeatherAPI(http);
 	}
 
-	async getJwt() {
-		try {
-			return await Promise.resolve(this.options.jwtGetter());
-		} catch {
-			return null;
-		}
+	getJwt() {
+		return from(Promise.resolve(this.options.jwtGetter()));
 	}
 
-	async setJwt(jwt: string, remember: boolean) {
-		return await Promise.resolve(this.options.jwtSetter(jwt, remember));
+	setJwt(jwt: string, remember?: boolean) {
+		return from(Promise.resolve(this.options.jwtSetter(jwt, remember)));
 	}
 
-	async clearJwt() {
-		return await Promise.resolve(this.options.jwtClear());
+	clearJwt() {
+		return from(Promise.resolve(this.options.jwtClear()));
 	}
 
 }


### PR DESCRIPTION
Support option for `jwtGetter`, `jwtSetter`, and `jwtClear` options to return a promise. In other words, they can use `async`/`await` for asynchronous storage.